### PR TITLE
Add createdAt field to Milestone and Task models

### DIFF
--- a/api/migrations/001.py
+++ b/api/migrations/001.py
@@ -1,0 +1,14 @@
+# This migration backfills createdAt field to Milestones
+
+from api.database import getDb
+from api.schemas import now
+
+if __name__ == "__main__":
+    db = getDb()
+
+    db.milestones.update_many(
+        {},
+        {"$set": {"createdAt": now()}},
+    )
+
+    print("Migration completed")

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -105,6 +105,7 @@ class Milestone(CreateableMilestone):
     id: MongoID = None
     status: Status = Status.todo
     tasks: list[str] = []
+    createdAt: datetime.datetime = Field(default_factory=now)
 
 
 class BaseCreateableTask(BaseModel):
@@ -144,7 +145,7 @@ class UpdateableTask(BaseUpdateableTask):
 class Task(CreateableTask):
     id: MongoID = None
     qaTask: BaseCreateableTask
-    createdAt: datetime.datetime = now()
+    createdAt: datetime.datetime = Field(default_factory=now)
 
 
 class CreateableSprint(BaseModel):


### PR DESCRIPTION
Fixes createdAt on task which happened since the datetime was only called once in the Task definition and used every time.

Also adds createdAt to Milestone which will be backfilled.

Will run `python3 -m api.migrations.001` on pod once deployed.